### PR TITLE
[Backend] Rename 'images' folder and table to 'memes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The whole application is based on Webpack, making the application secure and eff
    ```sql
    \c meme_generator
 
-   CREATE TABLE images (
+   CREATE TABLE memes (
        id SERIAL PRIMARY KEY,
        file_name TEXT NOT NULL,
        display_name TEXT NOT NULL,

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The whole application is based on Webpack, making the application secure and eff
    ```
 
    Additionally, you can update other variables in the `.env` file to customize the application behavior:
-   - **`IMAGES_FOLDER`**: Path to the folder where uploaded images will be stored (e.g., `uploads/images`).
+   - **`MEMES_FOLDER`**: Path to the folder where uploaded memes will be stored (e.g., `uploads/memes`).
    - **`TEMPLATES_FOLDER`**: Path to the folder where uploaded templates will be stored (e.g., `uploads/templates`).
    - **`ALLOWED_EXTENSIONS`**: Comma-separated list of allowed file extensions (e.g., `png,jpg,jpeg`).
    - **`ALLOWED_MIME_TYPES`**: Comma-separated list of allowed MIME types (e.g., `image/png,image/jpeg`).

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -9,8 +9,8 @@ app = Flask(__name__)
 
 app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['IMAGES_FOLDER'] = os.path.join(
-    os.path.dirname(__file__), '..', os.getenv('IMAGES_FOLDER')
+app.config['MEMES_FOLDER'] = os.path.join(
+    os.path.dirname(__file__), '..', os.getenv('MEMES_FOLDER')
 )
 app.config['TEMPLATES_FOLDER'] = os.path.join(
     os.path.dirname(__file__), '..', os.getenv('TEMPLATES_FOLDER')
@@ -21,8 +21,8 @@ app.config['MAX_CONTENT_LENGTH'] = int(os.getenv('MAX_CONTENT_LENGTH'))
 
 db = SQLAlchemy(app)
 
-if not os.path.exists(app.config['IMAGES_FOLDER']):
-    os.makedirs(app.config['IMAGES_FOLDER'])
+if not os.path.exists(app.config['MEMES_FOLDER']):
+    os.makedirs(app.config['MEMES_FOLDER'])
 
 if not os.path.exists(app.config['TEMPLATES_FOLDER']):
     os.makedirs(app.config['TEMPLATES_FOLDER'])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,9 +1,8 @@
 from app import db
 from datetime import datetime
 
-
-class Image(db.Model):
-    __tablename__ = 'images'
+class Meme(db.Model):
+    __tablename__ = 'memes'
 
     id = db.Column(db.Integer, primary_key=True)  # SERIAL PRIMARY KEY
     file_name = db.Column(db.String, nullable=False)  # TEXT NOT NULL

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -2,7 +2,7 @@ import os
 from flask import Blueprint, jsonify, request, send_from_directory, current_app
 from werkzeug.utils import secure_filename
 from app import db
-from app.models import Image, Template
+from app.models import Meme, Template
 import uuid
 
 main = Blueprint('main', __name__)
@@ -10,9 +10,9 @@ main = Blueprint('main', __name__)
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS']
 
-@main.route('/uploads/images/<filename>', methods=['GET'])
-def get_image_file(filename):
-    return send_from_directory(current_app.config['IMAGES_FOLDER'], filename)
+@main.route('/uploads/memes/<filename>', methods=['GET'])
+def get_meme_file(filename):
+    return send_from_directory(current_app.config['MEMES_FOLDER'], filename)
 
 @main.route('/uploads/templates/<filename>', methods=['GET'])
 def get_template_file(filename):
@@ -28,10 +28,10 @@ def api():
 
 @main.route('/api/memes', methods=['GET'])
 def get_memes():
-    images = Image.query.all()
-    if not images:
+    memes = Meme.query.all()
+    if not memes:
         return jsonify(message="No memes found."), 404
-    return jsonify([image.to_dict() for image in images])
+    return jsonify([meme.to_dict() for meme in memes])
 
 @main.route('/api/memes', methods=['POST'])
 def upload_meme():
@@ -69,11 +69,11 @@ def upload_meme():
         return jsonify(message="File extension is not allowed"), 400
 
     unique_filename = f"{uuid.uuid4().hex}.{file_ext}"
-    filepath = os.path.join(current_app.config['IMAGES_FOLDER'], unique_filename)
+    filepath = os.path.join(current_app.config['MEMES_FOLDER'], unique_filename)
     file.save(filepath)
 
-    image = Image(file_name=unique_filename, display_name=display_name, user_id=user_id)
-    db.session.add(image)
+    meme = Meme(file_name=unique_filename, display_name=display_name, user_id=user_id)
+    db.session.add(meme)
     db.session.commit()
 
     return jsonify(

--- a/backend/example.env
+++ b/backend/example.env
@@ -2,9 +2,8 @@
 DATABASE_URL=postgresql://<db_user>:<db_pass>@localhost/<db_name>
 
 # Folder for storing uploaded files
-IMAGES_FOLDER=uploads/images
+MEMES_FOLDER=uploads/memes
 TEMPLATES_FOLDER=uploads/templates
-
 
 # Allowed file extensions (comma-separated)
 ALLOWED_EXTENSIONS=png,jpg,jpeg


### PR DESCRIPTION
### What was changed
- Changed app config key from `IMAGES_FOLDER` to `MEMES_FOLDER`
- Updated filesystem check and folder creation logic
- Renamed SQLAlchemy model/table from `images` to `memes`
- Adjusted all relevant paths and environment variables

### Why it matters
Standardizes naming across backend to match updated naming conventions (memes instead of images).

### Required adjustment in the existing project
1. **Edit the `.env` file**  
Replace `IMAGES_FOLDER` with `MEMES_FOLDER`

```env
# before:
IMAGES_FOLDER=uploads/images

# after:
MEMES_FOLDER=uploads/memes
```

**2. Run the following SQL query**

```sql
ALTER TABLE images RENAME TO memes;
```
