### PR TITLE
[Backend] Hide user_id in GET /api/templates and /api/memes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub watchers](https://img.shields.io/github/watchers/damianczer/meme-generator?style=social) <br>
 ![GitHub issues](https://img.shields.io/github/issues/damianczer/meme-generator?style=flat-square) <br>
 
-**Authors:** [Damian Czerwiński](https://github.com/damianczer/) & [Dominik Grabowski](https://github.com/grabovv)
+**Authors:** [Damian Czerwiński](https://github.com/damianczer/) & [Dominik Grabowski](https://github.com/grabovv) 
 
 Technology: <br><br>
 React.js  - https://react.dev/ <br> 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,14 +10,16 @@ class Meme(db.Model):
     user_id = db.Column(db.Integer, nullable=True)  # INTEGER (optional)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)  # TIMESTAMP DEFAULT NOW()
 
-    def to_dict(self):
-        return {
+    def to_dict(self, include_user_id=False):
+        data = {
             "id": self.id,
             "file_name": self.file_name,
             "display_name": self.display_name,
-            "user_id": self.user_id,
             "created_at": self.created_at.isoformat() if self.created_at else None
         }
+        if include_user_id:
+            data["user_id"] = self.user_id
+        return data
 
 
 class Template(db.Model):
@@ -29,11 +31,13 @@ class Template(db.Model):
     user_id = db.Column(db.Integer, nullable=True)  # INTEGER (optional)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)  # TIMESTAMP DEFAULT NOW()
 
-    def to_dict(self):
-        return {
+    def to_dict(self, include_user_id=False):
+        data = {
             "id": self.id,
             "file_name": self.file_name,
             "display_name": self.display_name,
-            "user_id": self.user_id,
             "created_at": self.created_at.isoformat() if self.created_at else None
         }
+        if include_user_id:
+            data["user_id"] = self.user_id
+        return data


### PR DESCRIPTION
By default, `user_id` is no longer included in the responses of GET endpoints (`/api/templates`, `/api/memes`).  
If needed (e.g. for admin panels), it can be explicitly included by setting `include_user_id=True` in the query parameters.
